### PR TITLE
Fix mismatches in simulation config object's field names

### DIFF
--- a/src/app/simulation/simulation-configuration/SimulationConfigurationEditor.tsx
+++ b/src/app/simulation/simulation-configuration/SimulationConfigurationEditor.tsx
@@ -189,8 +189,13 @@ export class SimulationConfigurationEditor extends React.Component<Props, State>
   }
 
   onSimulationConfigurationFormGroupValueChanged(formValue: SimulationConfigurationFormGroupValue) {
-    for (const key in formValue)
-      this.currentConfig.simulation_config[key] = formValue[key];
+    this.currentConfig.simulation_config.start_time = formValue.startTime;
+    this.currentConfig.simulation_config.duration = formValue.duration;
+    this.currentConfig.simulation_config.simulator = formValue.simulator;
+    this.currentConfig.simulation_config.run_realtime = formValue.runInRealtime;
+    if (formValue.simulationName.includes('[NEW]'))
+      this.currentConfig.simulation_config.simulation_name = formValue.simulationName.replace('[NEW]', '');
+    this.currentConfig.simulation_config.model_creation_config = formValue.modelCreationConfig;
   }
 
   onApplicationConfigurationFormGroupValueChanged(formValue: ApplicationConfigurationFormGroupValue) {

--- a/src/app/simulation/simulation-configuration/views/SimulationConfigurationFormGroup/SimulationConfigurationFormGroup.tsx
+++ b/src/app/simulation/simulation-configuration/views/SimulationConfigurationFormGroup/SimulationConfigurationFormGroup.tsx
@@ -105,7 +105,7 @@ export class SimulationConfigurationFormGroup extends React.Component<Props, Sta
           name='simulation_name'
           value={this.state.simulationName}
           onChange={value => {
-            this.formValue.simulationName = value;
+            this.formValue.simulationName = `[NEW]${value}`;
             this.props.onChange(this.formValue);
           }} />
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/98)
<!-- Reviewable:end -->
