### PR TITLE
Bug fix: SVG elements on Safari refuse to take CSS width and height i…

### DIFF
--- a/src/app/topology-renderer/TopologyRenderer.tsx
+++ b/src/app/topology-renderer/TopologyRenderer.tsx
@@ -92,6 +92,8 @@ export class TopologyRenderer extends React.Component<Props, State> {
       <div className='model-renderer'>
         <svg
           ref={elem => this._svg = elem}
+          width='1000'
+          height='1000'
           className={this.props.topologyName}
           onClick={this.showMenuOnComponentClicked}
           onMouseOver={this.showTooltip}


### PR DESCRIPTION
…f no width and height attributes exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/103)
<!-- Reviewable:end -->
