### PR TITLE
npm build script now accepts @version and @host as optional arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "start": "node server.js",
         "launch": "webpack-dev-server --progress --inline",
-        "build": "rm -rf dist && webpack --env=production --env.BUILD_VERSION"
+        "build": "rm -rf dist && webpack --env=production"
     },
     "author": "",
     "license": "ISC",


### PR DESCRIPTION
`npm run build` now takes 2 optional arguments:
- `@version` changes the version number that will be displayed on the viz
- `@host` changes the GOSS server URL

Example:
`npm run build @version=1.0.0 @host=123.456.78.9:12345`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/110)
<!-- Reviewable:end -->
