### PR TITLE
Bug fix: If the 2 endpoints of a measurement chart's y axis extent ar…

### DIFF
--- a/src/app/shared/tabs/TabGroup.tsx
+++ b/src/app/shared/tabs/TabGroup.tsx
@@ -72,7 +72,7 @@ export class TabGroup extends React.Component<Props, State> {
             this.state.activeTab &&
             <div className='tabgroup__active-tab-indicator'
               style={{
-                // minus 4 because it has 2 px border
+                // minus 2 because it has 2 px border
                 transform: `translateX(${activeTab.offsetLeft - 2}px)`,
                 width: activeTab.clientWidth + 'px'
               }}>

--- a/src/app/simulation/measurement-chart/MeasurementChart.tsx
+++ b/src/app/simulation/measurement-chart/MeasurementChart.tsx
@@ -38,12 +38,12 @@ export class MeasurementChart extends React.Component<Props, State> {
 
   componentDidMount() {
     this._init();
-    this._render(this.props.measurementChartModel);
+    this._render();
   }
 
-  componentWillReceiveProps(newProps: Props) {
-    if (newProps.measurementChartModel !== this.props.measurementChartModel)
-      this._render(newProps.measurementChartModel);
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.measurementChartModel !== this.props.measurementChartModel)
+      this._render();
   }
 
   render() {
@@ -90,11 +90,12 @@ export class MeasurementChart extends React.Component<Props, State> {
       .y(dataPoint => this._yScale(dataPoint.primitiveY));
   }
 
-  private _render(measurementChartModel: MeasurementChartModel) {
+  private _render() {
     this._container.selectAll('*').remove();
 
-    const axisExtents = this._calculateXYAxisExtents(measurementChartModel.timeSeries);
-
+    const axisExtents = this._calculateXYAxisExtents(this.props.measurementChartModel.timeSeries);
+    if (axisExtents.yExtent[0] === axisExtents.yExtent[1])
+      axisExtents.yExtent[0] = 0;
     this._timeScale.domain(axisExtents.xExtent);
     this._yScale.domain(axisExtents.yExtent);
 

--- a/src/app/simulation/simulation-control/views/plot-model-creator/PlotModelCreator.scss
+++ b/src/app/simulation/simulation-control/views/plot-model-creator/PlotModelCreator.scss
@@ -22,10 +22,12 @@
 
     .form-control:nth-child(4) {
         margin-bottom: 0;
+        margin-left: 270px;
     }
 
     .form-control:nth-child(5) {
         margin-top: 5px;
+        margin-left: 270px;
     }
 }
 

--- a/src/app/simulation/simulation-labels/SimulationLabel.scss
+++ b/src/app/simulation/simulation-labels/SimulationLabel.scss
@@ -1,5 +1,5 @@
 .simulation-label {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 -0.5px 1px rgba(0, 0, 0, 0.2);

--- a/src/app/simulation/simulation-labels/SimulationLabel.tsx
+++ b/src/app/simulation/simulation-labels/SimulationLabel.tsx
@@ -49,12 +49,11 @@ export class SimulationLabel extends React.Component<Props, State> {
       if (anchor) {
         const anchorRect = anchor.getBoundingClientRect();
         const offsetTopOfOffsetParent = this.simulationLabel.offsetParent
-          ? (this.simulationLabel.offsetParent as HTMLElement).offsetTop
+          ? this.simulationLabel.offsetParent.getBoundingClientRect().top
           : 0;
-        const toolBarHeight = 60;
         return {
           left: anchorRect.left + anchorRect.width / 2,
-          top: anchorRect.top - offsetTopOfOffsetParent - toolBarHeight + anchorRect.height / 2
+          top: anchorRect.top - offsetTopOfOffsetParent
         };
       }
     }


### PR DESCRIPTION
…e equal, set the left endpoint to 0 so the y axis can render the tick marks properly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/166)
<!-- Reviewable:end -->
