### PR TITLE
Eagerly render all tabs in a tab group instead of rendering them lazily

### DIFF
--- a/src/app/shared/tabs/ActiveTabIndicator.tsx
+++ b/src/app/shared/tabs/ActiveTabIndicator.tsx
@@ -3,48 +3,25 @@ import * as React from 'react';
 import './ActiveTabIndicator.scss';
 
 interface Props {
-  activeTabIndex: number;
-  tabGroup: HTMLElement;
+  activeTab: HTMLElement;
 }
 
-interface State {
-  tabLabels: NodeListOf<HTMLElement>;
-}
-
-export class ActiveTabIndicator extends React.Component<Props, State> {
-
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      tabLabels: null
-    };
-  }
-
-  componentDidMount() {
-    this.setState({
-      tabLabels: this.queryTabLabels()
-    });
-  }
-
-  render() {
-    const tabLabels = this.queryTabLabels();
-    if (!tabLabels)
-      return null;
-    const activeTab = tabLabels[this.props.activeTabIndex];
-    return (
-      <div className='tabgroup__active-tab-indicator'
-        style={{
-          // minus 4 because it has 2 px border
-          transform: `translateX(${activeTab.offsetLeft - 2}px)`,
-          width: activeTab.clientWidth + 'px'
-        }}>
-        <div className='tabgroup__active-tab-indicator__rubber-band' />
-      </div>
-    );
-  }
-
-  queryTabLabels(): NodeListOf<HTMLElement> {
-    return this.props.tabGroup ? this.props.tabGroup.querySelectorAll('.tabgroup__header__label') as any : this.state.tabLabels;
-  }
-
+export function ActiveTabIndicator(props: Props) {
+  if (!props.activeTab)
+    return null;
+  const leftEdgeOfActiveTab = props.activeTab.offsetLeft;
+  // The container for tab lables can overflow and scroll
+  // So we need to know how much to the right it has scrolled,
+  // We get this distance, and subtract it from the left edge of the
+  // active tab currently on screen to position the indicator correctly
+  const offset = props.activeTab.parentElement ? props.activeTab.parentElement.scrollLeft : 0;
+  return (
+    <div className='tabgroup__active-tab-indicator'
+      style={{
+        // minus 2 because it has 2px border
+        transform: `translateX(${leftEdgeOfActiveTab - offset - 2}px)`,
+        width: props.activeTab.clientWidth + 'px'
+      }}>
+    </div>
+  );
 }

--- a/src/app/shared/tabs/TabGroup.tsx
+++ b/src/app/shared/tabs/TabGroup.tsx
@@ -82,7 +82,7 @@ export class TabGroup extends React.Component<Props, State> {
                     id={`tab-content-${index}`}
                     className='tab-content'
                     style={{
-                      visibility: activeTabIndex === index || previousTabIndex === index ? 'visible' : 'hidden'
+                      opacity: activeTabIndex === index || previousTabIndex === index ? 1 : 0
                     }}>
                     {
                       tab.props.children

--- a/src/app/shared/tabs/TabGroup.tsx
+++ b/src/app/shared/tabs/TabGroup.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Tab } from './Tab';
+import { ActiveTabIndicator } from './ActiveTabIndicator';
 
 import './TabGroup.scss';
 
@@ -68,17 +69,7 @@ export class TabGroup extends React.Component<Props, State> {
               </div>
             ))
           }
-          {
-            this.state.activeTab &&
-            <div className='tabgroup__active-tab-indicator'
-              style={{
-                // minus 2 because it has 2 px border
-                transform: `translateX(${activeTab.offsetLeft - 2}px)`,
-                width: activeTab.clientWidth + 'px'
-              }}>
-              <div className='tabgroup__active-tab-indicator__rubber-band' />
-            </div>
-          }
+          <ActiveTabIndicator activeTab={activeTab} />
         </header>
         <div className='tabgroup__body'>
           <div className='tabgroup__body__wrapper'>
@@ -89,10 +80,11 @@ export class TabGroup extends React.Component<Props, State> {
                   <div
                     key={index}
                     id={`tab-content-${index}`}
-                    className='tab-content'>
+                    className='tab-content'
+                    style={{
+                      visibility: activeTabIndex === index || previousTabIndex === index ? 'visible' : 'hidden'
+                    }}>
                     {
-                      (activeTabIndex === index || previousTabIndex === index)
-                      &&
                       tab.props.children
                     }
                   </div>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/168)
<!-- Reviewable:end -->
