### PR TITLE
Support both data time strings and epoch times with second precision …

### DIFF
--- a/src/app/shared/DateTimeService.ts
+++ b/src/app/shared/DateTimeService.ts
@@ -17,8 +17,13 @@ export class DateTimeService {
     return this._formatter(date);
   }
 
+  /**
+   * Parse the given date time string and return epoch time in second precision
+   * @param dateString Date time string in YYYY-MM-DD HH:MM:SS
+   */
   parse(dateString: string) {
-    return this._parser(dateString);
+    const parsedDateTime = this._parser(dateString);
+    return parsedDateTime ? parsedDateTime.getTime() / 1000 : null;
   }
 
 }

--- a/src/app/simulation/simulation-configuration/views/test-configuration/comm-outage/CommOutageEventForm.tsx
+++ b/src/app/simulation/simulation-configuration/views/test-configuration/comm-outage/CommOutageEventForm.tsx
@@ -500,13 +500,11 @@ export class CommOutageEventForm extends React.Component<Props, State> {
   }
 
   onStartDateTimeChanged(value: string) {
-    const parsedDateTime = this.dateTimeService.parse(value);
-    this.formValue.startDateTime = parsedDateTime ? parsedDateTime.getTime() / 1000 : null;
+    this.formValue.startDateTime = this.dateTimeService.parse(value);
   }
 
   onStopDateTimeChanged(value: string) {
-    const parsedDateTime = this.dateTimeService.parse(value);
-    this.formValue.stopDateTime = parsedDateTime ? parsedDateTime.getTime() / 1000 : null;
+    this.formValue.stopDateTime = this.dateTimeService.parse(value);
   }
 
   disableAddEventButton(): boolean {

--- a/src/app/simulation/simulation-configuration/views/test-configuration/fault/FaultEventForm.tsx
+++ b/src/app/simulation/simulation-configuration/views/test-configuration/fault/FaultEventForm.tsx
@@ -248,14 +248,12 @@ export class FaultEventForm extends React.Component<Props, State> {
   }
 
   onStartDateTimeChanged(value: string) {
-    const parsedDateTime = this.dateTimeService.parse(value);
-    this.formValue.startDateTime = parsedDateTime ? parsedDateTime.getTime() / 1000 : null;
+    this.formValue.startDateTime = this.dateTimeService.parse(value);
     this._enableAddEventButtonIfFormIsValid();
   }
 
   onStopDateTimeChanged(value: string) {
-    const parsedDateTime = this.dateTimeService.parse(value);
-    this.formValue.stopDateTime = parsedDateTime ? parsedDateTime.getTime() / 1000 : null;
+    this.formValue.stopDateTime = this.dateTimeService.parse(value);
     this._enableAddEventButtonIfFormIsValid();
   }
 


### PR DESCRIPTION
…in events file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/234)
<!-- Reviewable:end -->
