### PR TITLE
Bug fix: when consolidating the different phases for a single compone…

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -393,25 +393,24 @@ export class App extends React.Component<Props, State> {
           name,
           conductingEquipmentName: measurement.ConductingEquipment_name,
           conductingEquipmentType: measurement.ConductingEquipment_type,
-          displayName: `${name} (${phases})`,
-          phases: [phases],
-          conductingEquipmentMRIDs: [measurement.ConductingEquipment_mRID],
+          displayName: '',
+          phases: [],
+          conductingEquipmentMRIDs: [],
           type: measurement.measurementType as ModelDictionaryComponentType,
           measurementMRIDs: []
         };
-        measurementMRIDMap.set(id, [{ phase: phases, mrid: measurement.mRID }]);
+        measurementMRIDMap.set(id, []);
         componentWithGroupPhasesMap.set(id, componentInMeasurement);
-      } else {
-        if (!componentInMeasurement.phases.includes(phases)) {
-          const measurementMRIDAndPhaseArray = measurementMRIDMap.get(id);
-          measurementMRIDAndPhaseArray.push({ phase: phases, mrid: measurement.mRID });
-          componentInMeasurement.measurementMRIDs = measurementMRIDAndPhaseArray.sort(
-            (a, b) => a.phase.localeCompare(b.phase)
-          ).map(e => e.mrid);
-          componentInMeasurement.phases.push(phases);
-          componentInMeasurement.phases.sort((a, b) => a.localeCompare(b));
-          componentInMeasurement.displayName = `${name} (${componentInMeasurement.phases.join(', ')})`;
-        }
+      }
+      if (!componentInMeasurement.phases.includes(phases)) {
+        const measurementMRIDAndPhaseArray = measurementMRIDMap.get(id);
+        measurementMRIDAndPhaseArray.push({ phase: phases, mrid: measurement.mRID });
+        componentInMeasurement.measurementMRIDs = measurementMRIDAndPhaseArray.sort(
+          (a, b) => a.phase.localeCompare(b.phase)
+        ).map(e => e.mrid);
+        componentInMeasurement.phases.push(phases);
+        componentInMeasurement.phases.sort((a, b) => a.localeCompare(b));
+        componentInMeasurement.displayName = `${name} (${componentInMeasurement.phases.join(', ')})`;
         componentInMeasurement.conductingEquipmentMRIDs.push(measurement.ConductingEquipment_mRID);
       }
     }


### PR DESCRIPTION
…nt in model dictionary, we need to account for components with only one single phase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/241)
<!-- Reviewable:end -->
