### PR TITLE
If the search term matches exactly, then return early, and give the s…

### DIFF
--- a/src/app/shared/misc.ts
+++ b/src/app/shared/misc.ts
@@ -113,6 +113,19 @@ function _fuzzySearchWithHighlighting(needle: string) {
       startOfCurrentMatch = haystack.indexOf(piece, endOfLastMatch);
       if (startOfCurrentMatch === -1)
         return null;
+      // If the haystack is an exact match to the needle
+      // we want it to have the smallest possible inaccuracy
+      // which is negative infinity
+      // then we want to break out of the loop
+      if (needle === haystack) {
+        inaccuracy = -Infinity;
+        boundaries.push({
+          start: 0,
+          end: Infinity,
+          highlight: true
+        });
+        break;
+      }
       if (startOfCurrentMatch > endOfLastMatch) {
         boundaries.push({
           start: endOfLastMatch,


### PR DESCRIPTION
…earch result an inaccuracy of negative inifinity

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/247)
<!-- Reviewable:end -->
