### PR TITLE
- Only show loading indicator when beginning to fetch simulation logs

### DIFF
--- a/frontend/src/app/shared/simulation/SimulationManagementService.ts
+++ b/frontend/src/app/shared/simulation/SimulationManagementService.ts
@@ -119,12 +119,14 @@ export class SimulationManagementService {
 
   private _watchStompClientStatusChanges() {
     return this._stompClientService.statusChanges()
-      .pipe(filter(status => status === StompClientConnectionStatus.CONNECTED && this.didUserStartActiveSimulation()))
+      .pipe(filter(status => status === StompClientConnectionStatus.CONNECTED))
       .subscribe({
         next: () => {
-          this._simulationOutputSubscription?.unsubscribe();
-          this._simulationOutputSubscription = null;
-          this.stopSimulation();
+          if (this._simulationOutputSubscription !== null) {
+            this._simulationOutputSubscription.unsubscribe();
+            this._simulationOutputSubscription = null;
+            this.stopSimulation();
+          }
         }
       });
   }

--- a/frontend/src/app/simulation/simulation-status-logger/SimulationStatusLoggerContainer.tsx
+++ b/frontend/src/app/simulation/simulation-status-logger/SimulationStatusLoggerContainer.tsx
@@ -76,7 +76,7 @@ export class SimulationStatusLogContainer extends React.Component<Props, State> 
       .pipe(
         filter(status => status === StompClientConnectionStatus.CONNECTED),
         switchMap(() => this._stateStore.select('simulationId')),
-        filter(simulationId => simulationId !== ''),
+        filter(simulationId => simulationId !== '' && this._simulationManagementService.isUserInActiveSimulation()),
         switchMap(this._newObservableForLogMessages),
         takeUntil(this._unsubscriber)
       )


### PR DESCRIPTION
- Unscribe from existing simulation output subscription if there exists
  one active subscription and stomp client successfully reconnects

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/341)
<!-- Reviewable:end -->
