### PR TITLE
Fix Plot label for power and load demand plot

### DIFF
--- a/client/src/app/simulation/measurement-chart/MeasurementChartContainer.tsx
+++ b/client/src/app/simulation/measurement-chart/MeasurementChartContainer.tsx
@@ -410,10 +410,10 @@ export class MeasurementChartContainer extends Component<Props, State> {
           return measurement[plotModel.useMagnitude ? 'magnitude' : 'angle'];
         case MeasurementType.POWER:
           if (plotModel.useMagnitude) {
-return measurement['magnitude'] / 1000;
-} else {
-return measurement['angle'];
-}
+            return measurement['magnitude'] / 1000;
+          } else {
+            return measurement['angle'];
+          }
         case MeasurementType.TAP:
           return measurement.value;
       }

--- a/client/src/app/simulation/measurement-chart/MeasurementChartContainer.tsx
+++ b/client/src/app/simulation/measurement-chart/MeasurementChartContainer.tsx
@@ -235,15 +235,17 @@ export class MeasurementChartContainer extends Component<Props, State> {
   private _deriveYAxisLabel(plotModel: PlotModel) {
     switch (plotModel.measurementType) {
       case MeasurementType.POWER:
-        if (plotModel.useMagnitude)
-          return 'W';
-        else
-          return 'Degrees';
+        if (plotModel.useMagnitude) {
+return 'kVA';
+} else {
+return 'Degrees';
+}
       case MeasurementType.VOLTAGE:
-        if (plotModel.useMagnitude)
-          return 'V';
-        else
-          return 'Degrees';
+        if (plotModel.useMagnitude) {
+return 'V';
+} else {
+return 'Degrees';
+}
       case MeasurementType.TAP:
         return '';
       default:
@@ -342,7 +344,7 @@ export class MeasurementChartContainer extends Component<Props, State> {
 
     const loadDemandPlotModel = this._plotModels[1];
     const loadDemandRenderableChartModel = this._createDefaultRenderableChartModel(loadDemandPlotModel);
-    loadDemandRenderableChartModel.yAxisLabel = 'KVA';
+    loadDemandRenderableChartModel.yAxisLabel = 'kVA';
     loadDemandRenderableChartModel.timeSeries = [
       this._addValueToTimeSeries(this._findOrCreateTimeSeries(loadDemandPlotModel, loadDemandPlotModel.components[0]), energyConsumerP / 1000),
       this._addValueToTimeSeries(this._findOrCreateTimeSeries(loadDemandPlotModel, loadDemandPlotModel.components[1]), energyConsumerQ / 1000),
@@ -405,8 +407,13 @@ export class MeasurementChartContainer extends Component<Props, State> {
     if (measurement !== undefined) {
       switch (plotModel.measurementType) {
         case MeasurementType.VOLTAGE:
-        case MeasurementType.POWER:
           return measurement[plotModel.useMagnitude ? 'magnitude' : 'angle'];
+        case MeasurementType.POWER:
+          if (plotModel.useMagnitude) {
+return measurement['magnitude'] / 1000;
+} else {
+return measurement['angle'];
+}
         case MeasurementType.TAP:
           return measurement.value;
       }

--- a/client/src/app/simulation/measurement-chart/MeasurementChartContainer.tsx
+++ b/client/src/app/simulation/measurement-chart/MeasurementChartContainer.tsx
@@ -236,16 +236,16 @@ export class MeasurementChartContainer extends Component<Props, State> {
     switch (plotModel.measurementType) {
       case MeasurementType.POWER:
         if (plotModel.useMagnitude) {
-return 'kVA';
-} else {
-return 'Degrees';
-}
+          return 'kVA';
+        } else {
+          return 'Degrees';
+        }
       case MeasurementType.VOLTAGE:
         if (plotModel.useMagnitude) {
-return 'V';
-} else {
-return 'Degrees';
-}
+          return 'V';
+        } else {
+          return 'Degrees';
+        }
       case MeasurementType.TAP:
         return '';
       default:

--- a/client/src/app/simulation/measurement-chart/MeasurementChartContainer.tsx
+++ b/client/src/app/simulation/measurement-chart/MeasurementChartContainer.tsx
@@ -80,7 +80,7 @@ export class MeasurementChartContainer extends Component<Props, State> {
       finalChartModels.push(renderableChartModel);
     }
     if (finalChartModels[1].yAxisLabel === '') {
-      finalChartModels[1].yAxisLabel = 'KVA';
+      finalChartModels[1].yAxisLabel = 'kVA';
     }
     this.setState({
       renderableChartModels: finalChartModels
@@ -212,7 +212,7 @@ export class MeasurementChartContainer extends Component<Props, State> {
     // If Load Demand chart has no Y-axis label
     // we want to set it now
     if (renderableChartModels[1].yAxisLabel === '') {
-      renderableChartModels[1].yAxisLabel = 'KVA';
+      renderableChartModels[1].yAxisLabel = 'kVA';
     }
     this.setState({
       renderableChartModels


### PR DESCRIPTION
Fixed the Y axis labels for Power and load demand plots. Plotting measurements in kVA instead of VA on Power magnitude plot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-viz/441)
<!-- Reviewable:end -->
