### PR TITLE
Fix dropdown menu for Equipment types in Test Config Tab

### DIFF
--- a/client/src/app/simulation/simulation-configuration-editor/views/test-configuration-tab/comm-outage/CommOutageEventForm.tsx
+++ b/client/src/app/simulation/simulation-configuration-editor/views/test-configuration-tab/comm-outage/CommOutageEventForm.tsx
@@ -65,23 +65,42 @@ export class CommOutageEventForm extends Component<Props, State> {
       previousModelDictionary = props.modelDictionary;
     }
 
+    const labels = [];
+    if (this.props.modelDictionary.capacitors.length > 0) {
+      labels.push({label: 'Capacitor', id: 'capacitors'});
+    }
+    if (this.props.modelDictionary.disconnectors.length > 0) {
+      labels.push({label: 'disconnectors', id: 'disconnectors'});
+    }
+    if (this.props.modelDictionary.switches.length > 0) {
+      labels.push({label: 'switches', id: 'switches'});
+    }
+    if (this.props.modelDictionary.batteries.length > 0) {
+      labels.push({label: 'Battery', id: 'batteries'});
+    }
+    if (this.props.modelDictionary.breakers.length > 0) {
+      labels.push({label: 'Breaker', id: 'breakers'});
+    }
+    if (this.props.modelDictionary.fuses.length > 0) {
+      labels.push({label: 'Fuse', id: 'fuses'});
+    }
+    if (this.props.modelDictionary.reclosers.length > 0) {
+      labels.push({label: 'Recloser', id: 'reclosers'});
+    }
+    if (this.props.modelDictionary.regulators.length > 0) {
+      labels.push({label: 'Regulator', id: 'regulators'});
+    }
+    if (this.props.modelDictionary.sectionalisers.length > 0) {
+      labels.push({label: 'Sectionaliser', id: 'sectionalisers'});
+    }
+    if (this.props.modelDictionary.solarpanels.length > 0) {
+      labels.push({label: 'Solar Panel', id: 'solarpanels'});
+    }
+    if (this.props.modelDictionary.synchronousmachines.length > 0) {
+      labels.push({label: 'Synchronous Machine', id: 'synchronousmachines'});
+    }
     this.state = {
-      inputEquipmentTypeOptionBuilder: new SelectionOptionBuilder(
-        [
-          { id: 'batteries', label: 'Battery' },
-          { id: 'breakers', label: 'Breaker' },
-          { id: 'capacitors', label: 'Capacitor' },
-          { id: 'disconnectors', label: 'Disconnector' },
-          { id: 'fuses', label: 'Fuse' },
-          { id: 'reclosers', label: 'Recloser' },
-          { id: 'regulators', label: 'Regulator' },
-          { id: 'sectionalisers', label: 'Sectionaliser' },
-          { id: 'solarpanels', label: 'Solar Panel' },
-          { id: 'switches', label: 'Switch' },
-          { id: 'synchronousmachines', label: 'Synchronous Machine' }
-        ],
-        type => type.label
-      ),
+      inputEquipmentTypeOptionBuilder: new SelectionOptionBuilder(labels, type => type.label),
       inputComponentOptionBuilder: SelectionOptionBuilder.defaultBuilder(),
       inputPhaseOptionBuilder: SelectionOptionBuilder.defaultBuilder(),
       inputAttributeOptionBuilder: SelectionOptionBuilder.defaultBuilder(),

--- a/client/src/app/simulation/simulation-configuration-editor/views/test-configuration-tab/fault/FaultEventForm.tsx
+++ b/client/src/app/simulation/simulation-configuration-editor/views/test-configuration-tab/fault/FaultEventForm.tsx
@@ -37,25 +37,44 @@ export class FaultEventForm extends Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
+    const labels = [];
+    labels.push({label: 'ACLineSegment', id: 'ACLineSegment'});
+    labels.push({label: 'PowerTransformer', id: 'PowerTransformer'});
+    if (this.props.modelDictionary.capacitors.length > 0) {
+      labels.push({label: 'Capacitor', id: 'capacitors'});
+    }
+    if (this.props.modelDictionary.disconnectors.length > 0) {
+      labels.push({label: 'disconnectors', id: 'disconnectors'});
+    }
+    if (this.props.modelDictionary.switches.length > 0) {
+      labels.push({label: 'switches', id: 'switches'});
+    }
+    if (this.props.modelDictionary.batteries.length > 0) {
+      labels.push({label: 'Battery', id: 'batteries'});
+    }
+    if (this.props.modelDictionary.breakers.length > 0) {
+      labels.push({label: 'Breaker', id: 'breakers'});
+    }
+    if (this.props.modelDictionary.fuses.length > 0) {
+      labels.push({label: 'Fuse', id: 'fuses'});
+    }
+    if (this.props.modelDictionary.reclosers.length > 0) {
+      labels.push({label: 'Recloser', id: 'reclosers'});
+    }
+    if (this.props.modelDictionary.regulators.length > 0) {
+      labels.push({label: 'Regulator', id: 'regulators'});
+    }
+    if (this.props.modelDictionary.sectionalisers.length > 0) {
+      labels.push({label: 'Sectionaliser', id: 'sectionalisers'});
+    }
+    if (this.props.modelDictionary.solarpanels.length > 0) {
+      labels.push({label: 'Solar Panel', id: 'solarpanels'});
+    }
+    if (this.props.modelDictionary.synchronousmachines.length > 0) {
+      labels.push({label: 'Synchronous Machine', id: 'synchronousmachines'});
+    }
     this.state = {
-      equipmentTypeOptionBuilder: new SelectionOptionBuilder(
-        [
-          { label: 'ACLineSegment', id: 'ACLineSegment' },
-          { label: 'Battery', id: 'batteries' },
-          { label: 'Breaker', id: 'breakers' },
-          { label: 'Capacitor', id: 'capacitors' },
-          { label: 'Disconnector', id: 'disconnectors' },
-          { label: 'Fuse', id: 'fuses' },
-          { label: 'PowerTransformer', id: 'PowerTransformer' },
-          { label: 'Recloser', id: 'reclosers' },
-          { label: 'Regulator', id: 'regulators' },
-          { label: 'Sectionaliser', id: 'sectionalisers' },
-          { label: 'Solar Panel', id: 'solarpanels' },
-          { label: 'Switch', id: 'switches' },
-          { label: 'Synchronous Machine', id: 'synchronousmachines' }
-        ],
-        type => type.label
-      ),
+      equipmentTypeOptionBuilder: new SelectionOptionBuilder(labels, type => type.label),
       componentOptionBuilder: SelectionOptionBuilder.defaultBuilder(),
       phaseOptionBuilder: SelectionOptionBuilder.defaultBuilder(),
       faultKindOptionBuilder: new SelectionOptionBuilder(

--- a/client/src/app/simulation/simulation-configuration-editor/views/test-configuration-tab/scheduled-command/ScheduledCommandEventForm.tsx
+++ b/client/src/app/simulation/simulation-configuration-editor/views/test-configuration-tab/scheduled-command/ScheduledCommandEventForm.tsx
@@ -44,23 +44,42 @@ export class ScheduledCommandEventForm extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
+    const labels = [];
+    if (this.props.modelDictionary.capacitors.length > 0) {
+      labels.push({label: 'Capacitor', id: 'capacitors'});
+    }
+    if (this.props.modelDictionary.disconnectors.length > 0) {
+      labels.push({label: 'disconnectors', id: 'disconnectors'});
+    }
+    if (this.props.modelDictionary.switches.length > 0) {
+      labels.push({label: 'switches', id: 'switches'});
+    }
+    if (this.props.modelDictionary.batteries.length > 0) {
+      labels.push({label: 'Battery', id: 'batteries'});
+    }
+    if (this.props.modelDictionary.breakers.length > 0) {
+      labels.push({label: 'Breaker', id: 'breakers'});
+    }
+    if (this.props.modelDictionary.fuses.length > 0) {
+      labels.push({label: 'Fuse', id: 'fuses'});
+    }
+    if (this.props.modelDictionary.reclosers.length > 0) {
+      labels.push({label: 'Recloser', id: 'reclosers'});
+    }
+    if (this.props.modelDictionary.regulators.length > 0) {
+      labels.push({label: 'Regulator', id: 'regulators'});
+    }
+    if (this.props.modelDictionary.sectionalisers.length > 0) {
+      labels.push({label: 'Sectionaliser', id: 'sectionalisers'});
+    }
+    if (this.props.modelDictionary.solarpanels.length > 0) {
+      labels.push({label: 'Solar Panel', id: 'solarpanels'});
+    }
+    if (this.props.modelDictionary.synchronousmachines.length > 0) {
+      labels.push({label: 'Synchronous Machine', id: 'synchronousmachines'});
+    }
     this.state = {
-      componentTypeOptionBuilder: new SelectionOptionBuilder(
-        [
-          { label: 'Battery', id: 'batteries' },
-          { label: 'Breaker', id: 'breakers' },
-          { label: 'Capacitor', id: 'capacitors' },
-          { label: 'Disconnector', id: 'disconnectors' },
-          { label: 'Fuse', id: 'fuses' },
-          { label: 'Recloser', id: 'reclosers' },
-          { label: 'Regulator', id: 'regulators' },
-          { label: 'Sectionaliser', id: 'sectionalisers' },
-          { label: 'Solar Panel', id: 'solarpanels' },
-          { label: 'Switch', id: 'switches' },
-          { label: 'Synchronous Machine', id: 'synchronousmachines' }
-        ],
-        type => type.label
-      ),
+      componentTypeOptionBuilder: new SelectionOptionBuilder(labels,type => type.label),
       componentOptionBuilder: SelectionOptionBuilder.defaultBuilder(),
       attributeOptionBuilder: SelectionOptionBuilder.defaultBuilder(),
       selectedComponentType: ''


### PR DESCRIPTION
Fixes https://github.com/GRIDAPPSD/GOSS-GridAPPS-D/issues/1535
The dropdown menu displays equipment types that are present in the topology instead of all the components.